### PR TITLE
Fix invalid transactions and double spend transactions status update …

### DIFF
--- a/api/hXwPQrVhLEALFsIJ/index.js
+++ b/api/hXwPQrVhLEALFsIJ/index.js
@@ -5,7 +5,7 @@ import Endpoint from '../endpoint';
 /**
  * api list_config_public
  */
-class _CZOTAF5LfusB1Ht5 extends Endpoint {
+class _hXwPQrVhLEALFsIJ extends Endpoint {
     constructor() {
         super('hXwPQrVhLEALFsIJ');
         this.publicConfigNameList = new Set([
@@ -51,4 +51,4 @@ class _CZOTAF5LfusB1Ht5 extends Endpoint {
 }
 
 
-export default new _CZOTAF5LfusB1Ht5();
+export default new _hXwPQrVhLEALFsIJ();

--- a/core/config/config.js
+++ b/core/config/config.js
@@ -727,7 +727,7 @@ export const AUDIT_POINT_PRUNE_COUNT                           = 250;
 export const TRANSACTION_FEE_PROXY                             = 1000;
 export const TRANSACTION_FEE_DEFAULT                           = 1000;
 export const TRANSACTION_FEE_NETWORK                           = 0.0;
-export const TRANSACTION_PRUNE_AGE_MIN                         = 1440;
+export const TRANSACTION_PRUNE_AGE_MIN                         = 10;
 export const TRANSACTION_PRUNE_COUNT                           = 1000;
 export const TRANSACTION_RETRY_SYNC_MAX                        = 100;
 export const TRANSACTION_INPUT_MAX                             = 128;
@@ -784,7 +784,7 @@ export const NODE_CERTIFICATE_KEY_PATH                         = DATA_BASE_DIR +
 export const NODE_CERTIFICATE_PATH                             = DATA_BASE_DIR + '/node_certificate.pem';
 export const WALLET_KEY_PATH                                   = DATA_BASE_DIR + '/millix_private_key.json';
 export const JOB_CONFIG_PATH                                   = DATA_BASE_DIR + '/job.json';
-export const JOB_CONFIG_VERSION                                = 3;
+export const JOB_CONFIG_VERSION                                = 4;
 export const SHARD_ZERO_NAME                                   = 'shard_zero';
 export const PEER_ROTATION_MORE_THAN_AVERAGE                   = 0.5;
 export const PEER_ROTATION_MORE_THAN_MOST                      = 0.2;
@@ -818,7 +818,7 @@ if (DATABASE_ENGINE === 'sqlite') {
     DATABASE_CONNECTION.SCRIPT_INIT_MILLIX_JOB_ENGINE         = './scripts/initialize-millix-job-engine-sqlite3.sql';
     DATABASE_CONNECTION.SCRIPT_MIGRATION_DIR                  = './scripts/migration';
     DATABASE_CONNECTION.SCRIPT_MIGRATION_SHARD_DIR            = './scripts/migration/shard';
-    DATABASE_CONNECTION.SCHEMA_VERSION                        = '14';
+    DATABASE_CONNECTION.SCHEMA_VERSION                        = '15';
 }
 
 export default {

--- a/core/config/job.json
+++ b/core/config/job.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 4,
   "processor_list": {
     "localhost": {
       "instances": 2
@@ -280,25 +280,6 @@
         "run_always": 1,
         "run_delay": 10000,
         "enable": true
-      }
-    },
-    "transaction_output_refreshing": {
-      "type": "function",
-      "group": "wallet",
-      "processor": "localhost_wallet",
-      "payload": {
-        "module": "wallet",
-        "function_name": "_doTransactionOutputRefresh"
-      },
-      "object_list": [
-        "transaction",
-        "transaction_output"
-      ],
-      "priority": 0,
-      "option_list": {
-        "run_always": 1,
-        "run_delay": 600000,
-        "enable": false
       }
     },
     "node_attribute_update": {

--- a/core/wallet/wallet-utils.js
+++ b/core/wallet/wallet-utils.js
@@ -623,6 +623,19 @@ class WalletUtils {
             return false;
         }
 
+        let transactionDate;
+        if (![
+            '0a0',
+            '0b0',
+            'la0l',
+            'lb0l'
+        ].includes(transaction.version)) {
+            transactionDate = transaction.transaction_date;
+        }
+        else {
+            transactionDate = new Date(transaction.transaction_date).getTime() / 1000;
+        }
+
         const addressRepository                   = database.getRepository('address');
         //sort arrays
         transaction['transaction_output_list']    = _.sortBy(transaction.transaction_output_list, 'output_position');
@@ -637,7 +650,8 @@ class WalletUtils {
                 if (!this.isValidAddress(input.address_base)
                     || !this.isValidAddress(input.address_key_identifier)
                     || !addressRepository.supportedVersionSet.has(input.address_version)
-                    || outputUsedInTransaction.has(outputID)) {
+                    || outputUsedInTransaction.has(outputID)
+                    || transactionDate < input.output_transaction_date) {
                     return false;
                 }
                 outputUsedInTransaction.add(outputID);
@@ -781,8 +795,9 @@ class WalletUtils {
                 database.firstShards((shardID) => {
                     const transactionRepository = database.getRepository('transaction', shardID);
                     return transactionRepository.getTransactionOutput({
-                        transaction_id : input.output_transaction_id,
-                        output_position: input.output_position
+                        transaction_id        : input.output_transaction_id,
+                        output_position       : input.output_position,
+                        address_key_identifier: input.address_key_identifier
                     });
                 }).then(output => {
                     allocatedFunds += output.amount;

--- a/database/repositories/transaction.js
+++ b/database/repositories/transaction.js
@@ -153,9 +153,17 @@ export default class Transaction {
 
     getWalletUnstableTransactions(addressKeyIdentifier, excludeTransactionIDList) {
         return new Promise((resolve, reject) => {
-            this.database.all('SELECT DISTINCT `transaction`.* FROM `transaction` ' +
+            this.database.all('SELECT * FROM (SELECT `transaction`.* FROM `transaction` ' +
+                              'INNER JOIN transaction_input ON transaction_input.transaction_id = `transaction`.transaction_id ' +
+                              'INNER JOIN transaction_output ON transaction_output.transaction_id = transaction_input.transaction_id ' +
+                              'WHERE transaction_input.address_key_identifier = ?1 ' + (excludeTransactionIDList && excludeTransactionIDList.length > 0 ? 'AND `transaction`.transaction_id NOT IN (' + excludeTransactionIDList.map((_, idx) => `?${idx + 2}`).join(',') + ')' : '') + 'AND transaction_output.is_stable = 0 ORDER BY transaction_date LIMIT ' + config.CONSENSUS_VALIDATION_PARALLEL_PROCESS_MAX + ')' +
+                              'UNION SELECT * FROM (SELECT `transaction`.* FROM `transaction` ' +
                               'INNER JOIN transaction_output ON transaction_output.transaction_id = `transaction`.transaction_id ' +
-                              'WHERE transaction_output.address_key_identifier = ? ' + (excludeTransactionIDList && excludeTransactionIDList.length > 0 ? 'AND `transaction`.transaction_id NOT IN (' + excludeTransactionIDList.map(() => '?').join(',') + ')' : '') + 'AND transaction_output.is_stable = 0 AND transaction_output.is_spent=0 AND transaction_output.is_double_spend=0 AND `transaction`.status != 3 ORDER BY transaction_date LIMIT ' + config.CONSENSUS_VALIDATION_PARALLEL_PROCESS_MAX,
+                              'WHERE transaction_output.address_key_identifier = ?1 ' + (excludeTransactionIDList && excludeTransactionIDList.length > 0 ? 'AND `transaction`.transaction_id NOT IN (' + excludeTransactionIDList.map((_, idx) => `?${idx + 2}`).join(',') + ')' : '') + 'AND transaction_output.is_stable = 0 ORDER BY transaction_date LIMIT ' + config.CONSENSUS_VALIDATION_PARALLEL_PROCESS_MAX + ')' +
+                              'UNION SELECT * FROM (SELECT t.* FROM transaction_input i ' +
+                              'INNER JOIN `transaction` t ON t.transaction_id = i.transaction_id ' +
+                              'WHERE output_transaction_id IN (SELECT transaction_id FROM transaction_output WHERE address_key_identifier = ?1 ' +
+                              'AND is_stable = 1 AND is_spent = 1 AND status = 2) ' + (excludeTransactionIDList && excludeTransactionIDList.length > 0 ? 'AND `transaction`.transaction_id NOT IN (' + excludeTransactionIDList.map((_, idx) => `?${idx + 2}`).join(',') + ')' : '') + 'AND t.is_stable = 0 ORDER BY transaction_date LIMIT ' + config.CONSENSUS_VALIDATION_PARALLEL_PROCESS_MAX + ')',
                 [
                     addressKeyIdentifier
                 ].concat(excludeTransactionIDList),
@@ -384,6 +392,11 @@ export default class Transaction {
                     });
                     const addressList     = {};
                     const transactionDate = Math.floor(new Date(transaction.transaction_date).getTime() / 1000);
+                    // verify if expire time is greater than
+                    // transaction data
+                    const expireDate = ntp.now();
+                    expireDate.setMinutes(expireDate.getMinutes() - config.TRANSACTION_OUTPUT_EXPIRE_OLDER_THAN);
+                    const status = Math.round(expireDate.getTime() / 1000) < transactionDate ? 1 : 2;
 
                     transaction.transaction_parent_list.forEach(parentTransaction => {
                         promise = promise.then(() => {
@@ -433,7 +446,7 @@ export default class Transaction {
                                 return transactionRepository.getTransactionParentDate(transaction.transaction_id);
                             }).then(dates => resolve(_.min(dates)));
                         });
-                    }).then(parentDate => this.addTransaction(transaction.transaction_id, transaction.shard_id, transaction.payload_hash, transactionDate, transaction.node_id_origin, transaction.node_id_proxy, transaction.version, parentDate));
+                    }).then(parentDate => this.addTransaction(transaction.transaction_id, transaction.shard_id, transaction.payload_hash, transactionDate, transaction.node_id_origin, transaction.node_id_proxy, transaction.version, parentDate, undefined, undefined, status));
 
                     if (transaction.transaction_output_attribute) {
                         _.keys(transaction.transaction_output_attribute).forEach(attributeType => {
@@ -448,7 +461,7 @@ export default class Transaction {
 
                     transaction.transaction_input_list.forEach(input => {
                         promise = promise.then(() => {
-                            return this.addTransactionInput(transaction.transaction_id, transaction.shard_id, input.input_position, input.address, input.address_key_identifier, input.output_transaction_id, input.output_position, input.output_transaction_date, input.output_shard_id)
+                            return this.addTransactionInput(transaction.transaction_id, transaction.shard_id, input.input_position, input.address, input.address_key_identifier, input.output_transaction_id, input.output_position, input.output_transaction_date, input.output_shard_id, undefined, status)
                                        .then(() => {
                                            delete input['address'];
                                        });
@@ -471,11 +484,6 @@ export default class Transaction {
                                 }).then(dates => resolve(_.min(dates)));
                             });
                         }).then(spendDate => {
-                            // verify if expire time is greater than
-                            // transaction data
-                            let expireDate = ntp.now();
-                            expireDate.setMinutes(expireDate.getMinutes() - config.TRANSACTION_OUTPUT_EXPIRE_OLDER_THAN);
-                            const status = Math.round(expireDate.getTime() / 1000) < transactionDate ? 1 : 2;
                             return this.addTransactionOutput(transaction.transaction_id, transaction.shard_id, output.output_position, output.address, output.address_key_identifier, output.amount, spendDate, undefined, undefined, status)
                                        .then(() => {
                                            delete output['address'];
@@ -530,6 +538,11 @@ export default class Transaction {
                         runPipeline = r;
                     });
                     const transactionDate = Math.floor(transaction.transaction_date.getTime() / 1000);
+                    /* verify if expire time is greater than transaction date */
+                    const expireDate = ntp.now();
+                    expireDate.setMinutes(expireDate.getMinutes() - config.TRANSACTION_OUTPUT_EXPIRE_OLDER_THAN);
+                    const transactionStatus = transaction.status === 3 ? 3 :
+                                              Math.round(expireDate.getTime() / 1000) >= transactionDate ? 2 : 1;
 
                     transaction.transaction_parent_list.forEach(parentTransaction => {
                         promise = promise.then(() => {
@@ -570,13 +583,13 @@ export default class Transaction {
                             this.addTransaction(transaction.transaction_id, transaction.shard_id, transaction.payload_hash, transactionDate,
                                 transaction.node_id_origin, transaction.node_id_proxy, transaction.version, transaction.parent_date,
                                 transaction.stable_date, transaction.timeout_date,
-                                transaction.status, transaction.create_date)
+                                transactionStatus, transaction.create_date)
                                 .then(() => resolve())
                                 .catch(() => {
                                     this.updateTransaction(transaction.transaction_id, transaction.shard_id, transaction.payload_hash, transactionDate,
                                         transaction.node_id_origin, transaction.node_id_proxy, transaction.version, transaction.parent_date,
                                         transaction.stable_date, transaction.timeout_date,
-                                        transaction.status, transaction.create_date)
+                                        transactionStatus, transaction.create_date)
                                         .then(() => resolve())
                                         .catch(err => reject(err));
                                 });
@@ -600,10 +613,10 @@ export default class Transaction {
                             return new Promise((resolve, reject) => {
                                 this.addTransactionInput(transaction.transaction_id, transaction.shard_id, input.input_position, input.address, input.address_key_identifier,
                                     input.output_transaction_id, input.output_position, input.output_transaction_date, input.output_shard_id,
-                                    input.double_spend_date, input.status, input.create_date)
+                                    input.double_spend_date, transactionStatus, input.create_date)
                                     .then(resolve)
                                     .catch(() => {
-                                        this.updateTransactionInput(transaction.transaction_id, input.input_position, input.double_spend_date ? new Date(input.double_spend_date * 1000) : null)
+                                        this.updateTransactionInput(transaction.transaction_id, input.input_position, input.double_spend_date ? new Date(input.double_spend_date * 1000) : null, transactionStatus)
                                             .then(resolve)
                                             .catch(reject);
                                     });
@@ -616,19 +629,13 @@ export default class Transaction {
                     transaction.transaction_output_list.forEach(output => {
                         promise = promise.then(() => {
                             return new Promise((resolve, reject) => {
-                                // verify if expire time is greater than
-                                // transaction data
-                                let expireDate = ntp.now();
-                                expireDate.setMinutes(expireDate.getMinutes() - config.TRANSACTION_OUTPUT_EXPIRE_OLDER_THAN);
-                                const status = Math.round(expireDate.getTime() / 1000) < transactionDate ? 1 : 2;
-
                                 this.addTransactionOutput(transaction.transaction_id, transaction.shard_id, output.output_position, output.address, output.address_key_identifier,
                                     output.amount, output.spent_date, output.stable_date, output.double_spend_date,
-                                    status, output.create_date)
+                                    transactionStatus, output.create_date)
                                     .then(resolve)
                                     .catch(() => {
                                         this.updateTransactionOutput(transaction.transaction_id, output.output_position, output.spent_date ? new Date(output.spent_date * 1000) : null,
-                                            output.stable_date ? new Date(output.stable_date * 1000) : null, output.double_spend_date ? new Date(output.double_spend_date * 1000) : null, status)
+                                            output.stable_date ? new Date(output.stable_date * 1000) : null, output.double_spend_date ? new Date(output.double_spend_date * 1000) : null, transactionStatus)
                                             .then(resolve)
                                             .catch(reject);
                                     });
@@ -921,7 +928,7 @@ export default class Transaction {
         });
     }
 
-    updateTransactionInput(transactionID, inputPosition, doubleSpendDate) {
+    updateTransactionInput(transactionID, inputPosition, doubleSpendDate, status) {
         return new Promise((resolve, reject) => {
             let sql        = 'UPDATE transaction_input SET';
             let parameters = [];
@@ -933,6 +940,11 @@ export default class Transaction {
             else if (doubleSpendDate) {
                 sql += ' double_spend_date = ?, is_double_spend = ?';
                 parameters.push(Math.floor(doubleSpendDate.getTime() / 1000), 1);
+            }
+
+            if (status !== undefined) {
+                sql += ', status = ?';
+                parameters.push(status);
             }
 
             parameters.push(transactionID, inputPosition);
@@ -1007,45 +1019,65 @@ export default class Transaction {
         });
     }
 
-    getTransactionSpenders(transactionID, shardID, outputPosition) {
+    invalidateAllTransactions(transactionID) {
         return new Promise((resolve, reject) => {
-            let sql          = 'WITH RECURSIVE transaction_spender (transaction_id, shard_id, output_position) as (\
-                                SELECT ?, ?, ? \
-                                UNION ALL \
-                                SELECT o.transaction_id, o.shard_id, o.output_position FROM transaction_output o INNER JOIN transaction_input i ON o.transaction_id = i.transaction_id INNER JOIN transaction_spender s ON i.output_transaction_id = s.transaction_id AND i.output_position = s.output_position \
-                                LIMIT 100000 ) \
-                                SELECT DISTINCT transaction_id, shard_id FROM transaction_spender';
-            const parameters = [
-                transactionID,
-                shardID,
-                outputPosition
-            ];
-            this.database.all(sql, parameters, (err, rows) => {
-                if (err) {
-                    return reject(err);
-                }
-
-                let result = rows.map(r => {
-                    return {
-                        'transaction_id': r.transaction_id,
-                        'shard_id'      : r.shard_id
-                    };
+            this.database.serialize(() => {
+                let sql = `DROP TABLE IF EXISTS transaction_invalid_all;
+                CREATE TEMPORARY TABLE transaction_invalid_all AS
+                with recursive transaction_invalid_spenders (transaction_id, status)
+                                   as (
+                        select "${transactionID}", 2
+                        union
+                        select i.transaction_id, i.status
+                        from transaction_input i
+                                 inner join transaction_invalid_spenders s
+                                            on i.output_transaction_id = s.transaction_id
+                    )
+                select transaction_id
+                from transaction_invalid_spenders where status != 3;
+                update 'transaction'
+                set status      = 3,
+                    is_stable   = 1,
+                    stable_date = CAST(strftime('%s', 'now') AS INTEGER)
+                where transaction_id in
+                      (select transaction_id from transaction_invalid_all);
+                update transaction_output
+                set status            = 3,
+                    is_stable         = 1,
+                    stable_date       = CAST(strftime('%s', 'now') AS INTEGER),
+                    is_double_spend   = 0,
+                    double_spend_date = NULL,
+                    is_spent          = 0,
+                    spent_date        = NULL
+                where transaction_id in
+                      (select transaction_id from transaction_invalid_all);
+                update transaction_input
+                set status            = 3,
+                    is_double_spend   = 0,
+                    double_spend_date = NULL
+                where transaction_id in
+                      (select transaction_id from transaction_invalid_all);
+                update transaction_output as o
+                set stable_date = CAST(strftime('%s', 'now') AS INTEGER), is_spent = exists (
+                    select o2.transaction_id from transaction_input i
+                    inner join transaction_output o2 on i.transaction_id = o2.transaction_id
+                    where i.output_transaction_id = o.transaction_id and i.output_position = o.output_position and
+                    o2.status != 3 and o2.is_double_spend = 0
+                    ), spent_date = (
+                    select t.transaction_date from 'transaction' t
+                    inner join transaction_input i on i.transaction_id = t.transaction_id
+                    inner join transaction_output o2 on i.transaction_id = o2.transaction_id
+                    where i.output_transaction_id = o.transaction_id and i.output_position = o.output_position and
+                    o2.status != 3 and o2.is_double_spend = 0
+                    )
+                where transaction_id in (select output_transaction_id from transaction_input where transaction_id in (select transaction_id from transaction_invalid_all));
+                DROP TABLE transaction_invalid_all;`;
+                this.database.exec(sql, (err) => {
+                    if (err) {
+                        return reject();
+                    }
+                    return resolve();
                 });
-
-                resolve(result);
-            });
-        });
-    }
-
-    markTransactionsAsInvalid(transactionIDs) {
-        return new Promise((resolve, reject) => {
-            this.database.run('UPDATE `transaction` set status = 3 WHERE transaction_id IN (' + transactionIDs.map(() => '?').join(',') + ' )', transactionIDs, err => {
-                if (err) {
-                    reject(err);
-                }
-                else {
-                    resolve();
-                }
             });
         });
     }
@@ -1333,7 +1365,7 @@ export default class Transaction {
             let unstableDateStart = ntp.now();
             unstableDateStart.setMinutes(unstableDateStart.getMinutes() - config.TRANSACTION_OUTPUT_EXPIRE_OLDER_THAN);
             unstableDateStart = Math.floor(unstableDateStart.getTime() / 1000);
-            this.database.all('SELECT DISTINCT `transaction`.* FROM `transaction` INNER JOIN  transaction_output ON `transaction`.transaction_id = transaction_output.transaction_id WHERE `transaction`.transaction_date > ? AND `transaction`.create_date < ? AND transaction_output.is_stable = 0 ' + (excludeTransactionIDList && excludeTransactionIDList.length > 0 ? 'AND `transaction`.transaction_id NOT IN (' + excludeTransactionIDList.map(() => '?').join(',') + ')' : '') + ' AND `transaction`.status != 3 ORDER BY transaction_date LIMIT ' + config.CONSENSUS_VALIDATION_PARALLEL_PROCESS_MAX,
+            this.database.all('SELECT DISTINCT `transaction`.* FROM `transaction` INNER JOIN  transaction_output ON `transaction`.transaction_id = transaction_output.transaction_id WHERE `transaction`.transaction_date > ? AND `transaction`.create_date < ? AND `transaction`.is_stable = 0 ' + (excludeTransactionIDList && excludeTransactionIDList.length > 0 ? 'AND `transaction`.transaction_id NOT IN (' + excludeTransactionIDList.map(() => '?').join(',') + ')' : '') + ' AND `transaction`.status != 3 ORDER BY transaction_date LIMIT ' + config.CONSENSUS_VALIDATION_PARALLEL_PROCESS_MAX,
                 [
                     unstableDateStart,
                     insertDate
@@ -1479,19 +1511,16 @@ export default class Transaction {
                                         database.applyShardZeroAndShardRepository('transaction', transaction.shard_id, transactionRepository => transactionRepository.updateTransactionOutput(transaction.transaction_id, output.output_position, now, now, now))
                                                 .then(() => callbackOutputs());
                                     }, () => {
-                                        async.eachSeries(transaction.transaction_input_list, (input, callbackInputs) => { // get all transactions spending  this input
+                                        async.eachSeries(transaction.transaction_input_list, (input, callbackInputs) => { // reset spent date of the output spent by this transaction
                                             (() => {
-                                                if (input.output_transaction_id === doubleSpendTransactionInput.output_transaction_id &&
-                                                    input.output_position === doubleSpendTransactionInput.output_position) {
-                                                    return Promise.resolve();
-                                                }
-                                                else {
-                                                    return database.applyShards((shardID) => database.getRepository('transaction', shardID).listOutputSpendTransaction(input.output_transaction_id, input.output_position))
-                                                                   .then(transactions => { // update the spend date using the oldest date
-                                                                       let spendDate = _.min(_.map(_.filter(transactions, t => t.transaction_id !== transaction.transaction_id), t => t.transaction_date));
-                                                                       return database.applyShardZeroAndShardRepository('transaction', input.output_shard_id, transactionRepository => transactionRepository.updateTransactionOutput(input.output_transaction_id, input.output_position, !spendDate ? null : spendDate));
-                                                                   });
-                                                }
+                                                return database.applyShards((shardID) => {
+                                                    const transactionRepository = database.getRepository('transaction', shardID);
+                                                    return transactionRepository.getOutputSpendDate(input.output_transaction_id, input.output_position)
+                                                                                .then(spendDate => !!spendDate ? Promise.resolve(spendDate) : Promise.reject());
+                                                }).then(spendDate => {
+                                                    spendDate = spendDate.length > 0 ? new Date(_.min(spendDate) * 1000) : undefined;
+                                                    return database.applyShardZeroAndShardRepository('transaction', input.output_shard_id, transactionRepository => transactionRepository.updateTransactionOutput(input.output_transaction_id, input.output_position, !spendDate ? null : spendDate));
+                                                });
                                             })().then(() => { // mark the input as  double spend if it caused the double spend issue.
                                                 if (input.output_transaction_id === doubleSpendTransactionInput.output_transaction_id &&
                                                     input.output_position === doubleSpendTransactionInput.output_position) {
@@ -1702,7 +1731,7 @@ export default class Transaction {
         });
     }
 
-    listOutputSpendTransaction(transactionID, outputPosition) {
+    listTransactionSpendingOutput(transactionID, outputPosition) {
         return new Promise((resolve, reject) => {
             this.database.all('SELECT * FROM `transaction` INNER JOIN transaction_input ON `transaction`.transaction_id = transaction_input.transaction_id WHERE output_transaction_id = ? AND output_position = ?',
                 [
@@ -1731,13 +1760,15 @@ export default class Transaction {
         });
     }
 
-    getTransactionOutputSpendDate(transactionID, outputShardID, outputPosition) {
+    getOutputSpendDate(transactionID, outputPosition) {
         return new Promise((resolve, reject) => {
-            this.database.get('SELECT min(transaction_date) as transaction_date from `transaction` AS t INNER JOIN transaction_input AS i on t.transaction_id = i.transaction_id \
-                               WHERE i.output_transaction_id = ? AND i.output_shard_id = ? and i.output_position = ?',
+            this.database.get('SELECT min(transaction_date) as transaction_date from `transaction` t \
+                                inner join transaction_input i on i.transaction_id = t.transaction_id \
+                                inner join transaction_output o on i.transaction_id = o.transaction_id \
+                                where i.output_transaction_id = ? and i.output_position = ? \
+                                and o.status != 3 and o.is_double_spend = 0',
                 [
                     transactionID,
-                    outputShardID,
                     outputPosition
                 ],
                 (err, data) => {
@@ -1771,7 +1802,7 @@ export default class Transaction {
                                                          async.eachSeries(outputs, (output, callback) => {
                                                              database.applyShards((shardID) => {
                                                                  const transactionRepositorySpendDate = database.getRepository('transaction', shardID);
-                                                                 return transactionRepositorySpendDate.getTransactionOutputSpendDate(output.transaction_id, output.shard_id, output.output_position)
+                                                                 return transactionRepositorySpendDate.getOutputSpendDate(output.transaction_id, output.output_position)
                                                                                                       .then(spendDate => !!spendDate ? Promise.resolve(spendDate) : Promise.reject());
                                                              }).then(spendDate => {
                                                                  spendDate = spendDate.length > 0 ? new Date(_.min(spendDate) * 1000) : undefined;
@@ -1855,22 +1886,11 @@ export default class Transaction {
         });
     }
 
-    getFreeStableOutput(addressKeyIdentifier) {
-        return new Promise((resolve) => {
-            this.database.all('SELECT transaction_output.*, `transaction`.transaction_date FROM transaction_output \
-                              INNER JOIN `transaction` ON `transaction`.transaction_id = transaction_output.transaction_id \
-                              WHERE transaction_output.address_key_identifier=? and is_spent = 0 and transaction_output.is_stable = 1 and transaction_output.status != 2 and is_double_spend = 0',
-                [addressKeyIdentifier], (err, rows) => {
-                    resolve(rows);
-                });
-        });
-    }
-
     getFreeOutput(addressKeyIdentifier) {
         return new Promise((resolve) => {
             this.database.all('SELECT transaction_output.*, `transaction`.transaction_date FROM transaction_output \
                               INNER JOIN `transaction` ON `transaction`.transaction_id = transaction_output.transaction_id \
-                              WHERE transaction_output.address_key_identifier=? and is_spent = 0 and transaction_output.is_stable = 1 and is_double_spend = 0',
+                              WHERE transaction_output.address_key_identifier=? and is_spent = 0 and transaction_output.is_stable = 1 and is_double_spend = 0 and transaction_output.status != 3',
                 [addressKeyIdentifier], (err, rows) => {
                     resolve(rows);
                 });
@@ -2039,25 +2059,6 @@ export default class Transaction {
                         return reject(err);
                     }
                     resolve(row.count);
-                }
-            );
-        });
-    }
-
-    getOutputSpendDate(outputTransactionID, outputPosition) {
-        return new Promise((resolve, reject) => {
-            this.database.get('SELECT `transaction`.transaction_date FROM transaction_input INNER JOIN `transaction` on transaction_input.transaction_id = `transaction`.transaction_id ' +
-                              'WHERE output_transaction_id = ? AND output_position = ? AND `transaction`.status != 3 ' +
-                              'AND NOT EXISTS(SELECT transaction_output.transaction_id FROM transaction_output WHERE transaction_output.transaction_id = `transaction`.transaction_id AND transaction_output.is_double_spend = 1)', [
-                    outputTransactionID,
-                    outputPosition
-                ],
-                (err, row) => {
-                    if (err) {
-                        console.log(err);
-                        return reject(err);
-                    }
-                    resolve(row ? row.transaction_date : null);
                 }
             );
         });
@@ -2274,7 +2275,7 @@ export default class Transaction {
                                 else {
                                     if (_.some(_.map(transaction.transaction_input_list, input => keyIdentifierSet.has(input.address_key_identifier)))
                                         || _.some(_.map(transaction.transaction_output_list, output => keyIdentifierSet.has(output.address_key_identifier)))) {
-                                        return this.setTransactionAsPrunable(transaction.transaction_id);
+                                        return this.setTransactionAsExpired(transaction.transaction_id);
                                     }
                                     else {
                                         return this.deleteTransaction(transaction.transaction_id);
@@ -2291,15 +2292,13 @@ export default class Transaction {
         });
     }
 
-    setTransactionAsPrunable(transactionID) {
-        return new Promise((resolve, reject) => {
-            this.database.run('UPDATE `transaction` SET status = 2 WHERE transaction_id = ?', [transactionID],
-                (err) => {
-                    if (err) {
-                        return reject(err);
-                    }
-                    return resolve();
-                });
+    setTransactionAsExpired(transactionID) {
+        return new Promise((resolve) => {
+            this.database.serialize(() => {
+                this.database.run('UPDATE transaction_output set status = 2 WHERE transaction_id = ? AND status = 1', [transactionID], _ => _);
+                this.database.run('UPDATE transaction_input set status = 2 WHERE transaction_id = ? AND status = 1', [transactionID], _ => _);
+                this.database.run('UPDATE `transaction` set status = 2 WHERE transaction_id = ? AND status = 1', [transactionID], _ => resolve());
+            });
         });
     }
 
@@ -2418,6 +2417,18 @@ export default class Transaction {
         });
     }
 
+    getMissingInputTransactions() {
+        return new Promise((resolve, reject) => {
+            this.database.all('select output_transaction_id as transaction_id from transaction_input where output_transaction_id not in (select transaction_id from `transaction`)',
+                (err, transactions) => {
+                    if (err) {
+                        console.log(err);
+                        return reject(err);
+                    }
+                    resolve(transactions);
+                });
+        });
+    }
 
     expireTransactions(olderThan) {
         return database.applyShards((shardID) => {
@@ -2429,7 +2440,27 @@ export default class Transaction {
         let seconds = Math.floor(olderThan.valueOf() / 1000);
 
         return new Promise((resolve, reject) => {
-            this.database.run('UPDATE transaction_output set status = 2 WHERE is_spent = 0 AND EXISTS (SELECT T.transaction_id FROM `transaction` AS T WHERE T.transaction_date <= ? AND T.transaction_id = transaction_output.transaction_id)', seconds, (err) => {
+            this.database.exec(`DROP TABLE IF EXISTS transaction_expired;
+            CREATE TEMPORARY TABLE transaction_expired AS
+            WITH expired AS (SELECT transaction_id
+                             FROM 'transaction'
+                             WHERE transaction_date <= ${seconds}
+                               AND status = 1)
+            SELECT *
+            FROM expired;
+            UPDATE transaction_output
+            set status = 2
+            WHERE transaction_id IN
+                  (SELECT transaction_id FROM transaction_expired);
+            UPDATE transaction_input
+            set status = 2
+            WHERE transaction_id IN
+                  (SELECT transaction_id FROM transaction_expired);
+            UPDATE 'transaction'
+            set status = 2
+            WHERE transaction_id IN
+                  (SELECT transaction_id FROM transaction_expired);
+            DROP TABLE IF EXISTS transaction_expired;`, err => {
                 if (err) {
                     console.log('[Database] Failed updating transactions to expired. [message] ', err);
                     reject(err);
@@ -2437,27 +2468,6 @@ export default class Transaction {
                 else {
                     resolve();
                 }
-            });
-        });
-    }
-
-    getUnspentTransactionOutputsOlderThanOrExpired(addressKeyIdentifier, time) {
-        const createDate = Math.floor(time.valueOf() / 1000);
-        // only refresh outputs stable since 30s ago
-        const stableDate = Math.floor(Date.now() / 1000) - 60;
-
-        return new Promise((resolve, reject) => {
-            // TODO - return only necessary
-            this.database.all('SELECT transaction_output.*, `transaction`.transaction_date FROM transaction_output INNER JOIN `transaction` ON `transaction`.transaction_id = transaction_output.transaction_id WHERE (`transaction`.transaction_date <= ? OR transaction_output.status = 2) AND transaction_output.address_key_identifier = ? AND transaction_output.is_spent = 0 AND transaction_output.is_double_spend = 0 AND `transaction`.is_stable = 1 AND `transaction`.stable_date < ?', [
-                createDate,
-                addressKeyIdentifier,
-                stableDate
-            ], (err, rows) => {
-                if (err) {
-                    return reject(err);
-                }
-
-                resolve(rows);
             });
         });
     }

--- a/net/network.js
+++ b/net/network.js
@@ -655,6 +655,11 @@ class Network {
             _.pull(this._nodeRegistry[ws.nodeID], ws);
             if (this._nodeRegistry[ws.nodeID] && this._nodeRegistry[ws.nodeID].length === 0) {
                 delete this._nodeRegistry[ws.nodeID];
+                database.getRepository('node')
+                        .updateNode({
+                            ...this._nodeList[ws.node],
+                            status: 1
+                        }).then(_ => _);
             }
 
             // remove from inbound or outbound registry
@@ -663,12 +668,6 @@ class Network {
             if (registry[ws.nodeID] && registry[ws.nodeID].length === 0) {
                 delete registry[ws.nodeID];
             }
-
-            database.getRepository('node')
-                    .updateNode({
-                        ...this._nodeList[ws.node],
-                        status: !this._nodeRegistry[ws.nodeID] ? 1 : 2
-                    }).then(_ => _);
         }
 
         // update bidirectional stream slots

--- a/net/peer.js
+++ b/net/peer.js
@@ -866,14 +866,14 @@ class Peer {
             return Promise.resolve();
         }
 
-        return (forceRequestSync ? Promise.resolve() : walletSync.getTransactionUnresolvedData(transactionID))
+        return (forceRequestSync || options.routing ? Promise.resolve() : walletSync.getTransactionUnresolvedData(transactionID))
             .then(unresolvedTransaction => {
                 if (unresolvedTransaction) {
                     return;
                 }
                 return new Promise((resolve, reject) => {
 
-                    if (!alreadyQueued) {
+                    if (!alreadyQueued && !options.routing) {
                         walletSync.add(transactionID, {
                             delay: !dispatchRequest ? 0 : config.NETWORK_LONG_TIME_WAIT_MAX * 10,
                             timestamp,
@@ -951,7 +951,7 @@ class Peer {
 
                         if (!done) {
                             console.log('[peer] transaction_sync_response:' + transactionID + ' not received. skip...');
-                            if (!alreadyQueued) {
+                            if (!alreadyQueued && !options.routing) {
                                 walletSync.add(transactionID, {
                                     timestamp,
                                     attempt,

--- a/scripts/initialize-millix-shard-sqlite3.sql
+++ b/scripts/initialize-millix-shard-sqlite3.sql
@@ -73,6 +73,7 @@ CREATE TABLE transaction_input
     PRIMARY KEY (transaction_id, input_position),
     FOREIGN KEY (transaction_id) REFERENCES `transaction` (transaction_id)
 );
+CREATE INDEX idx_transaction_input_status_output_transaction_id ON transaction_input (status, output_transaction_id);
 CREATE INDEX idx_transaction_input_address_key_identifier ON transaction_input (address_key_identifier);
 CREATE INDEX idx_transaction_input_address_is_double_spend ON transaction_input (address, is_double_spend);
 CREATE INDEX idx_transaction_input_transaction_id ON transaction_input (transaction_id);
@@ -98,7 +99,8 @@ CREATE TABLE transaction_output
     PRIMARY KEY (transaction_id, output_position),
     FOREIGN KEY (transaction_id) REFERENCES `transaction` (transaction_id)
 );
-CREATE INDEX idx_transaction_output_address_key_identifier ON transaction_output (address_key_identifier);
+CREATE INDEX idx_transaction_output_address_key_identifier_is_stable_is_spent_status ON transaction_output (address_key_identifier, is_stable, is_spent, status);
+CREATE INDEX idx_transaction_output_address_key_identifier_spent_double_spend_status ON transaction_output (address_key_identifier, is_spent, is_double_spend, status);
 CREATE INDEX idx_transaction_output_address_is_spent ON transaction_output (address, is_spent);
 CREATE INDEX idx_transaction_output_address_create_date ON transaction_output (address, create_date);
 CREATE INDEX idx_transaction_output_address_is_stable_is_spent_is_double_spend ON transaction_output (address, is_stable, is_spent, is_double_spend);

--- a/scripts/initialize-millix-sqlite3.sql
+++ b/scripts/initialize-millix-sqlite3.sql
@@ -96,7 +96,7 @@ CREATE TABLE `transaction`
     is_parent        TINYINT     NOT NULL DEFAULT 0 CHECK (is_parent = 0 OR is_parent = 1),
     timeout_date     INT         NULL CHECK(length(timeout_date) <= 10 AND TYPEOF(timeout_date) IN ('integer', 'null')),
     is_timeout       TINYINT     NOT NULL DEFAULT 0 CHECK (is_timeout = 0 OR is_timeout = 1),
-    status           TINYINT     NOT NULL DEFAULT 1 CHECK (length(status) <= 3 AND TYPEOF(status) = 'integer'), /*1: default, 2: prune, 3: invalid*/
+    status           TINYINT     NOT NULL DEFAULT 1 CHECK (length(status) <= 3 AND TYPEOF(status) = 'integer'), /*1: default, 2: expired, 3: invalid*/
     create_date      INT         NOT NULL DEFAULT (CAST(strftime('%s', 'now') AS INTEGER)) CHECK(length(create_date) <= 10 AND TYPEOF(create_date) = 'integer')
 );
 CREATE INDEX idx_transaction_status_is_stable_transaction_date ON `transaction` (status, is_stable, transaction_date);
@@ -154,6 +154,7 @@ CREATE TABLE transaction_input
     FOREIGN KEY (transaction_id) REFERENCES `transaction` (transaction_id),
     FOREIGN KEY (address, address_key_identifier) REFERENCES address (address, address_key_identifier)
 );
+CREATE INDEX idx_transaction_input_status_output_transaction_id ON transaction_input (status, output_transaction_id);
 CREATE INDEX idx_transaction_input_address_key_identifier ON transaction_input (address_key_identifier);
 CREATE INDEX idx_transaction_input_address_is_double_spend ON transaction_input (address, is_double_spend);
 CREATE INDEX idx_transaction_input_transaction_id ON transaction_input (transaction_id);
@@ -180,7 +181,8 @@ CREATE TABLE transaction_output
     FOREIGN KEY (transaction_id) REFERENCES `transaction` (transaction_id),
     FOREIGN KEY (address, address_key_identifier) REFERENCES address (address, address_key_identifier)
 );
-CREATE INDEX idx_transaction_output_address_key_identifier ON transaction_output (address_key_identifier);
+CREATE INDEX idx_transaction_output_address_key_identifier_is_stable_is_spent_status ON transaction_output (address_key_identifier, is_stable, is_spent, status);
+CREATE INDEX idx_transaction_output_address_key_identifier_spent_double_spend_status ON transaction_output (address_key_identifier, is_spent, is_double_spend, status);
 CREATE INDEX idx_transaction_output_address_is_spent ON transaction_output (address, is_spent);
 CREATE INDEX idx_transaction_output_address_create_date ON transaction_output (address, create_date);
 CREATE INDEX idx_transaction_output_address_is_stable_is_spent_is_double_spend ON transaction_output (address, is_stable, is_spent, is_double_spend);

--- a/scripts/migration/schema-update-15.sql
+++ b/scripts/migration/schema-update-15.sql
@@ -1,0 +1,14 @@
+PRAGMA foreign_keys= off;
+
+BEGIN TRANSACTION;
+
+DROP INDEX IF EXISTS idx_transaction_input_status_output_transaction_id;
+DROP INDEX IF EXISTS idx_transaction_output_address_key_identifier_is_stable_is_spent_status;
+DROP INDEX IF EXISTS idx_transaction_output_address_key_identifier_spent_double_spend_status;
+CREATE INDEX idx_transaction_input_status_output_transaction_id ON transaction_input (status, output_transaction_id);
+CREATE INDEX idx_transaction_output_address_key_identifier_is_stable_is_spent_status ON transaction_output (address_key_identifier, is_stable, is_spent, status);
+CREATE INDEX idx_transaction_output_address_key_identifier_spent_double_spend_status ON transaction_output (address_key_identifier, is_spent, is_double_spend, status);
+
+UPDATE schema_information SET value = "15" WHERE key = "version";
+
+COMMIT;

--- a/scripts/migration/shard/schema-update-15.sql
+++ b/scripts/migration/shard/schema-update-15.sql
@@ -1,0 +1,14 @@
+PRAGMA foreign_keys= off;
+
+BEGIN TRANSACTION;
+
+DROP INDEX IF EXISTS idx_transaction_input_status_output_transaction_id;
+DROP INDEX IF EXISTS idx_transaction_output_address_key_identifier_is_stable_is_spent_status;
+DROP INDEX IF EXISTS idx_transaction_output_address_key_identifier_spent_double_spend_status;
+CREATE INDEX idx_transaction_input_status_output_transaction_id ON transaction_input (status, output_transaction_id);
+CREATE INDEX idx_transaction_output_address_key_identifier_is_stable_is_spent_status ON transaction_output (address_key_identifier, is_stable, is_spent, status);
+CREATE INDEX idx_transaction_output_address_key_identifier_spent_double_spend_status ON transaction_output (address_key_identifier, is_spent, is_double_spend, status);
+
+UPDATE schema_information SET value = "15" WHERE key = "version";
+
+COMMIT;


### PR DESCRIPTION
…(#9)

* fix api class name

* remove transaction auto refresh code

* remove auto-refresh job

* update transaction status

* fix transaction status on insert. improve sql statement on update status

* update tx prune age

* verify key identifier when retrieving outputs from db

* allow sync expired outputs

* change error status on balance unavailable

* validate transaction input address

* verify if transaction date is greater than the input transactions date

* update is_stable state when a transaction is invalidated

* update query in findUnstableTransaction

* fix node connection status update

* fix output address verification of new transactions

* consensus: verify transaction status

* update transaction output spend date

* improve transaction invalidation process. fix output spent date when resetting double spent state. add indexes to improve database performance.

* fix migration script

* check output status when selecting outputs to use in a new transaction