### PR TITLE
Issue/millix 64 (#34)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ git clone https://github.com/millix/millix-node.git -b develop
 ## Run millix-node
 ```
 cd millix-node
-vi run-millix-node.sh.sh
+vi run-millix-node.sh
 #replace “127.0.0.1” with your ip  (find by whatismyip)
 ```
 

--- a/api/LOLb7q23p8rYSLwv/index.js
+++ b/api/LOLb7q23p8rYSLwv/index.js
@@ -1,0 +1,25 @@
+import Endpoint from "../endpoint";
+import WalletUtils from '../../core/wallet/wallet-utils'
+
+/**
+ * api get_is_key_present
+ */
+class _LOLb7q23p8rYSLwv extends Endpoint {
+    constructor() {
+        super('LOLb7q23p8rYSLwv');
+    }
+
+    handler(app, req, res) {
+        WalletUtils.loadMnemonic().then(() => {
+            return res.send({
+                is_key_exists: true
+            })
+        })
+            .catch(e => res.send({
+                api_status: 'fail',
+                api_message: `unexpected generic api error: (${e})`
+            }))
+    }
+}
+
+export default new _LOLb7q23p8rYSLwv();

--- a/core/config/api.json
+++ b/core/config/api.json
@@ -494,6 +494,15 @@
       "version_released": "1.11.5",
       "permission": "{\"require_identity\": true, \"private\": true}",
       "enable": true
+    },
+    {
+      "id": "LOLb7q23p8rYSLwv",
+      "name": "get_is_key_present",
+      "description": "returns boolean value of presence of private_key.json",
+      "method": "GET",
+      "version_released": "1.11.5",
+      "permission": "{\"require_identity\": true, \"private\": false}",
+      "enable": true
     }
   ]
 }


### PR DESCRIPTION
* Update README.md

* Update README.md

* Update README.md

* Update README.md

* set master configurations

* Update README: change repo url

* bump version 1.3.0

* bump version 1.3.1

* bump version 1.3.2

* bump version 1.3.3

* bump version 1.3.4

* bump version 1.3.5

* bump version 1.3.6

* improve millix-node run from script.
save node_id and node_signature to node.js at millix-node's data folder.

* fix program arguments

* improve gracefully shutting down from  SIGINT

* improve peer rotation. change process title.

* fix shard attribute check.

* improve peer rotation

* bump version 1.3.7

* add verification: replace node in a consensus round

* fix consensus code

* do double spend search on all available shards.

* [hot-fix] WALLET_TRANSACTION_DEFAULT_VERSION config value

* add missing migration scripts

* disable debug

* don't propagate sync for tx hash that have exceeded the max tries;

* Update README.md

* Fix invalid transactions and double spend transactions status update (#9) (#10)

* fix api class name

* remove transaction auto refresh code

* remove auto-refresh job

* update transaction status

* fix transaction status on insert. improve sql statement on update status

* update tx prune age

* verify key identifier when retrieving outputs from db

* allow sync expired outputs

* change error status on balance unavailable

* validate transaction input address

* verify if transaction date is greater than the input transactions date

* update is_stable state when a transaction is invalidated

* update query in findUnstableTransaction

* fix node connection status update

* fix output address verification of new transactions

* consensus: verify transaction status

* update transaction output spend date

* improve transaction invalidation process. fix output spent date when resetting double spent state. add indexes to improve database performance.

* fix migration script

* check output status when selecting outputs to use in a new transaction

Co-authored-by: Eriksson <erikssonmonteiro@gmail.com>

* bump version 1.11.2

* bump version 1.11.3

* bump version 1.11.4

* bump version 1.11.5

* update readme

* bump version 1.11.6

* MILLIX-21: get node config by name

* MILLIX-21: get node public IP

* MILLIX-21: config

* update consensus round configurations. increase number of peers.

* bump version 1.12.6

* Release/v1.12.7 (#26)

* Merge pull request #22 from dkhaleev/issue/MILLIX-21

Issue/millix 21

(cherry picked from commit 0de6280e69ff53ec16a38a7bc15f521a1a8f8560)

* bump version 1.12.7

Co-authored-by: millix <38732277+millix@users.noreply.github.com>

* Update README.md

* MILLIX-64: is key exists

* MILLIX-38: login form

* MILLIX-64: restored old config

* MILLIX-64: updated formatting

Co-authored-by: Eriksson Monteiro <erikssonmonteiro@gmail.com>
Co-authored-by: millix <38732277+millix@users.noreply.github.com>